### PR TITLE
more explicit celery and redis dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ MySQL-python==1.2.4c1
 simplejson
 South==0.7.6
 django-celery==3.0.11
-celery-with-redis==3.0
+celery>=3.0,<4.0
+redis>=2.4.4
 -e git://github.com/edx/django-pipeline.git@c5a4848d3d8fa90a7da4a4007f5653be40cccdd9#egg=django_pipeline-dev
 -e git://github.com/edx/django-staticfiles.git@6d2504e5c84a3003b4573e0ba0f11adf7583d372#egg=django_staticfiles-dev


### PR DESCRIPTION
celery-with-redis is just a shortcut for:
celery>=3.0,<4.0
redis>=2.4.4
