### PR TITLE
Remove unused simplejson requrement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ gunicorn
 path.py
 decorator
 MySQL-python==1.2.4c1
-simplejson
 South==0.7.6
 django-celery==3.0.11
 celery-with-redis==3.0


### PR DESCRIPTION
We're not using it anywhere, and the json module is bundled with python 2.6+
