### PR TITLE
Add an OEP-2 compliant openedx.yaml file

### DIFF
--- a/openedx.yaml
+++ b/openedx.yaml
@@ -1,0 +1,5 @@
+# This file describes this Open edX repo, as described in OEP-2:
+# http://open-edx-proposals.readthedocs.io/en/latest/oeps/oep-0002.html#specification
+
+oeps: {}
+owner: MUST FILL IN OWNER

--- a/openedx.yaml
+++ b/openedx.yaml
@@ -2,4 +2,4 @@
 # http://open-edx-proposals.readthedocs.io/en/latest/oeps/oep-0002.html#specification
 
 oeps: {}
-owner: MUST FILL IN OWNER
+owner: edx/analytics

--- a/openedx.yaml
+++ b/openedx.yaml
@@ -3,3 +3,4 @@
 
 oeps: {}
 owner: edx/analytics
+obsolete: true


### PR DESCRIPTION

This adds an `openedx.yaml` file, as described by OEP-2:
http://open-edx-proposals.readthedocs.io/en/latest/oeps/oep-0002.html

The data in this file was transformed from the contents of
edx/repo-tools-data:repos.yaml
